### PR TITLE
Do not override environment variables if they are explicitly set

### DIFF
--- a/dreamer.py
+++ b/dreamer.py
@@ -7,8 +7,11 @@ import pathlib
 import sys
 import time
 
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-os.environ['MUJOCO_GL'] = 'egl'
+# Do not override environment variables if they are explicitly set
+if 'TF_CPP_MIN_LOG_LEVEL' not in os.environ:
+  os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+if 'MUJOCO_GL' not in os.environ:
+  os.environ['MUJOCO_GL'] = 'egl'
 
 import numpy as np
 import tensorflow as tf


### PR DESCRIPTION
Hard-coding the environment variable in code is restrictive, and some environments do not have EGL-compatible drivers (users normally set MUJOCO_GL to osmesa or glfw)