### PR TITLE
Fix wrappers bug

### DIFF
--- a/wrappers.py
+++ b/wrappers.py
@@ -176,6 +176,7 @@ class Collect:
 
   def reset(self):
     obs = self._env.reset()
+    obs = {k: self._convert(v) for k, v in obs.items()}
     transition = obs.copy()
     transition['action'] = np.zeros(self._env.action_space.shape)
     transition['reward'] = 0.0

--- a/wrappers.py
+++ b/wrappers.py
@@ -343,7 +343,7 @@ class RewardObs:
   def observation_space(self):
     spaces = self._env.observation_space.spaces
     assert 'reward' not in spaces
-    spaces['reward'] = gym.spaces.Box(-np.inf, np.inf, dtype=np.float32)
+    spaces['reward'] = gym.spaces.Box(-np.inf, np.inf, (), dtype=np.float32)
     return gym.spaces.Dict(spaces)
 
   def step(self, action):


### PR DESCRIPTION
Minor bugs:
- gym.spaces.Box instance requires shape to be provided or to be inferred from the shapes of low or high. Since both low and high are scalars here, shape argument is required.
- obs dtype is converted in the method step and not in the method reset
